### PR TITLE
not receiving touch events; due to missing pressure

### DIFF
--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, str::FromStr};
+use std::{alloc::System, fs::File, str::FromStr};
 
 use chrono::{DateTime, Duration, Utc};
 use evdev_rs::{Device, InputEvent, ReadFlag, ReadStatus};
@@ -102,6 +102,9 @@ impl TouchEventListener {
                             x = Some(screen_size.x - event.value);
                         }
                         evdev_rs::enums::EV_ABS::ABS_PRESSURE => {
+                            pressure = Some(event.value);
+                        }
+                        evdev_rs::enums::EV_ABS::ABS_MT_PRESSURE => {
                             pressure = Some(event.value);
                         }
                         _ => {}

--- a/src/input/touch.rs
+++ b/src/input/touch.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::{fs::File, str::FromStr};
 
 use chrono::{DateTime, Duration, Utc};
 use evdev_rs::{Device, InputEvent, ReadFlag, ReadStatus};
@@ -32,7 +32,10 @@ impl TouchEventListener {
     /// Construct a new `TouchEventListener` by opening the event stream
     pub fn open() -> std::io::Result<Self> {
         // Open the touch device
-        let file = File::open("/dev/input/event1")?;
+        let touch_path: String = std::env::var("KOBO_TS_INPUT")
+            .or(String::from_str("/dev/input/event1"))
+            .unwrap();
+        let file = File::open(touch_path)?;
         let device = Device::new_from_file(file)?;
 
         Ok(Self { device })


### PR DESCRIPTION
I've not received any touch events, despite I saw the being present when reading /dev/input/eventX on the device with a terminal.
Turned out that the pressure is sent as `ABS_MT_PRESSURE` at least on my Kobo H20 with firmware 4.38.

Builds upon #12  ... so for easier tracing you may better merge the other first.